### PR TITLE
memsize: scan maps more efficiently 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
-go: "1.10.x"
+go:
+  - "1.10.x"
+  - "1.11.x"
+  - "1.12.x"
 env:
   - GOARCH=i386
   - GOARCH=amd64

--- a/mapiter_go12.go
+++ b/mapiter_go12.go
@@ -1,0 +1,12 @@
+// +build go1.12
+
+package memsize
+
+import "reflect"
+
+func iterateMap(m reflect.Value, fn func(k, v reflect.Value)) {
+	it := m.MapRange()
+	for it.Next() {
+		fn(it.Key(), it.Value())
+	}
+}

--- a/mapiter_old.go
+++ b/mapiter_old.go
@@ -1,0 +1,11 @@
+// +build !go1.12
+
+package memsize
+
+import "reflect"
+
+func iterateMap(m reflect.Value, fn func(k, v reflect.Value)) {
+	for _, k := range m.MapKeys() {
+		fn(k, m.MapIndex(k))
+	}
+}

--- a/memsize.go
+++ b/memsize.go
@@ -223,10 +223,10 @@ func (c *context) scanMap(v reflect.Value) uintptr {
 		extra = uintptr(0)
 	)
 	if c.tc.needScan(typ.Key()) || c.tc.needScan(typ.Elem()) {
-		for _, k := range v.MapKeys() {
+		iterateMap(v, func(k, v reflect.Value) {
 			extra += c.scan(invalidAddr, k, false)
-			extra += c.scan(invalidAddr, v.MapIndex(k), false)
-		}
+			extra += c.scan(invalidAddr, v, false)
+		})
 	} else {
 		extra = len*typ.Key().Size() + len*typ.Elem().Size()
 	}


### PR DESCRIPTION
Avoid allocating a slice for all keys using the new MapIter feature
on Go 1.12 and above.