### PR TITLE
memsize: compatibility with go 1.21

### DIFF
--- a/memsize.go
+++ b/memsize.go
@@ -18,7 +18,7 @@ func Scan(v interface{}) Sizes {
 		panic("value to scan must be non-nil pointer")
 	}
 
-	stopTheWorld("memsize scan")
+	stopTheWorld(stwReadMemStats)
 	defer startTheWorld()
 
 	ctx := newContext()

--- a/runtimefunc.go
+++ b/runtimefunc.go
@@ -4,9 +4,6 @@ import "unsafe"
 
 var _ = unsafe.Pointer(nil)
 
-//go:linkname stopTheWorld runtime.stopTheWorld
-func stopTheWorld(reason string)
-
 //go:linkname startTheWorld runtime.startTheWorld
 func startTheWorld()
 

--- a/runtimefunc_go120.go
+++ b/runtimefunc_go120.go
@@ -1,0 +1,13 @@
+//go:build !go1.21
+// +build !go1.21
+
+package memsize
+
+import "unsafe"
+
+var _ = unsafe.Pointer(nil)
+
+const stwReadMemStats string = "memsize scan"
+
+//go:linkname stopTheWorld runtime.stopTheWorld
+func stopTheWorld(reason string)

--- a/runtimefunc_go120.s
+++ b/runtimefunc_go120.s
@@ -1,0 +1,1 @@
+// This file is required to make stub function declarations work.

--- a/runtimefunc_go121.go
+++ b/runtimefunc_go121.go
@@ -1,0 +1,17 @@
+//go:build go1.21
+// +build go1.21
+
+package memsize
+
+import "unsafe"
+
+var _ = unsafe.Pointer(nil)
+
+//go:linkname stwReason runtime.stwReason
+type stwReason uint8
+
+//go:linkname stwReadMemStats runtime.stwReadMemStats
+const stwReadMemStats stwReason = 7
+
+//go:linkname stopTheWorld runtime.stopTheWorld
+func stopTheWorld(reason stwReason)

--- a/runtimefunc_go121.s
+++ b/runtimefunc_go121.s
@@ -1,0 +1,1 @@
+// This file is required to make stub function declarations work.


### PR DESCRIPTION
The internal function signatures of the standard lib changed in go 1.21.... so memsize needs to adapt to the new ones.
I tried to keep backwards compatibility.

I tested go 1.20 and go 1.21.